### PR TITLE
Handle bogus repository input

### DIFF
--- a/.bin/ish
+++ b/.bin/ish
@@ -73,14 +73,19 @@ Usage:
     if (res.status >= 400) {
       throw new Error("Bad response from server");
     }
+    
+    const { data } = await res.json();
+
+    if (!data.repository) {
+      console.error(chalk.red(`Could not resolve repository ${owner}/${repo}`));
+      process.exit(1);
+    }
 
     const {
-      data: {
-        repository: {
-          issues: { edges }
-        }
+      repository: {
+        issues: { edges }
       }
-    } = await res.json();
+    } = data;
 
     edges.forEach(({ node: { title, url } }) => {
       console.log();


### PR DESCRIPTION
Handles a `null` repository in the server response:

```
❯ ish foo/baaz
Could not resolve repository foo/baaz
```